### PR TITLE
proposed to maybe change \Slim\Middleware\ContentTypes

### DIFF
--- a/src/Slim/Middleware/ContentTypes.php
+++ b/src/Slim/Middleware/ContentTypes.php
@@ -75,8 +75,7 @@ class ContentTypes extends \Slim\Middleware
         $mediaType = $this->app->request->getMediaType();
         if ($mediaType) {
             $env = $this->app->environment;
-            $env['slim.input_original'] = $env['slim.input'];
-            $env['slim.input'] = $this->parse($env['slim.input'], $mediaType);
+            $env['slim.input_parsed'] = $this->parse($env['slim.input'], $mediaType);
         }
         $this->next->call();
     }


### PR DESCRIPTION
Hello,

\Slim\Middleware\ContentTypes, replaces environment[slim.input] with a parsed version.
This has the side effect, that $app->request->getBody() now returns the parsed request body which effectively breaks the documentation which clearly states to return "the raw HTTP request body".

This in turn forces all code that still wants to get the raw request body, to be aware of the possibility that ContentTypes was added to the application. Regardless if this code is itself a middleware and has nothing to do with the ContentTypes middleware.

I became aware of this issue, when I wanted to add ContentTypes, but some old code would break. So I now need to touch working code, which I don't like. Plus I just have a religious issue against coupling unrelated things :)

Since any change would break existing code out there, I propose the following:
- If _nobody_ uses codeguy/Slim-Middleware yet (since ContentTypes is already included in codeguy/Slim), I would make the change.
- If somebody already uses it, I would create a new middleware (maybe "ParseRequest") with changed semantics and deprecate ContentTypes.

regards,

Max
