### PR TITLE
Added improved implementation of CSRF guard with ajax protection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 composer.lock
 vendor/
+.idea

--- a/src/Slim/Middleware/CsrfGuardNeue.php
+++ b/src/Slim/Middleware/CsrfGuardNeue.php
@@ -1,0 +1,353 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: www.sib.li
+ * Date: 13.08.14
+ * Time: 13:29
+ */
+
+namespace Slim\Middleware;
+
+/**
+ * Class CsrfGuardNeue
+ *
+ * Based on CsrfGuard middleware from Slim-Extras
+ * https://github.com/codeguy/Slim-Extras/blob/develop/Middleware/CsrfGuard.php
+ *
+ *
+ * Provides CSRF(XSRF) protection for your forms and ajax requests.
+ * https://www.owasp.org/index.php/Cross-Site_Request_Forgery_(CSRF)_Prevention_Cheat_Sheet
+ *
+ *
+ * Implements cookie set + http header check for ajax requests
+ * and csrf_token (hidden input) for forms.
+ * ( if your are familiar with Django, check here:
+ *   https://docs.djangoproject.com/en/dev/ref/contrib/csrf/ )
+ *
+ * Compatible with AngularJS $http provider:
+ * https://docs.angularjs.org/api/ng/service/$http#cross-site-request-forgery-xsrf-protection
+ *
+ *
+ * Usage:
+ * $app = new \Slim\Slim();
+ * $app->add( new \Slim\Middleware\CsrfGuardNeue() );
+ *
+ * You can configure hidden input name like this:
+ * $csrfGuard = new \Slim\Middleware\CsrfGuardNeue('myCustomName');
+ * $app->add( $csrfGuard );
+ *
+ * Or configure other parameters passing array (here provided their default values)
+ * $csrfGuard = new \Slim\Middleware\CsrfGuardNeue( array(
+ *     'field'  => 'csrfmiddlewaretoken', // Input name
+ *     'cookie' => 'XSRF-TOKEN',          // Cookie name
+ *     'header' => 'X-Xsrf-Token',        // Header name
+ *     // Action on CSRF validation failure
+ *     // Should be callable function. $app will be passed inside when called.
+ *     'action' => function(\Slim\Slim $app) {
+ *         $app->halt(400, '"Invalid or missing CSRF token"');
+ *     }
+ * ) );
+ * $app->add( $csrfGuard );
+ *
+ *
+ * In your view template add this input inside every of web forms you have created:
+ * <input type="hidden" name="<?php echo $csrf_key; ?>" value="<?php echo $csrf_token; ?>">
+ *
+ * Or, with Twig, you can use provided extension:
+ * $app->view->parserExtensions = array(
+ *     new \Slim\Views\TwigExtension(),
+ *     new \Slim\Middleware\CsrfGuardNeue\TwigCsrfHelpers()
+ * );
+ * And insert inside forms:
+ * <form ...> {{ CSRF() }} ...</form>
+ * This will be translated to:
+ * <form ...> <input type="hidden" name="{{ csrf_key }}" value="{{ csrf_token }}" /> ...</form>
+ *
+ *
+ *
+ * For jQuery users:
+ * If you get data for all of your ajax POST requests from $("form").serialize() or $.serializeArray(),
+ * you need nothing else to configure, just make sure you put hidden input in every form (see above).
+ * See also: http://api.jquery.com/serializeArray/
+ *
+ * For any other ajax POST, PUT or DELETE requests you will need some additional setup:
+ * (this needed to copy CSRF token value from cookie to request header for every unsafe request):
+ * <script>
+ * function getCookie(cname) {
+ *     var name = cname + '=';
+ *     var ca = document.cookie.split(';');
+ *     for (var i = 0; i < ca.length; i++) {
+ *         var c = $.trim(ca[i]);
+ *         if (c.indexOf(name) != -1) return c.substring(name.length,c.length);
+ *     }
+ *     return null;
+ * }
+ * $.ajaxSetup({
+ *     beforeSend: function(xhr, settings) {
+ *         if (this.crossDomain) return;
+ *         // These HTTP methods do not require CSRF protection, BUT!
+ *         // Only if you are not changing any data using these methods in ajax!
+ *         if ( -1 < (['GET','HEAD','OPTIONS','TRACE']).indexOf(settings.type) ) return;
+ *         var csrftoken = $.cookie ? $.cookie('XSRF-TOKEN') : getCookie('XSRF-TOKEN');
+ *         xhr.setRequestHeader("X-XSRF-TOKEN", csrftoken);
+ *     }
+ * });
+ * </script>
+ *
+ * If you are using Twig template engine, add provided extension (see above), and place somewhere
+ * before closing </body> this line:
+ * {{ jQcsrf() }}
+ * That will be translated to the jQuery code from above.
+ *
+ *
+ * Limitations
+ * Any sub-domains of your site will be able to get and set cookies (client-side) for the whole domain.
+ * In this case Cookie+Header protection is useless.
+ * If you have untrusted sub-domains, disable cookie assignment by setting cookie option to false:
+ * $csrfGuard = new \Slim\Middleware\CsrfGuardNeue( array('cookie' => false) );
+ * $app->add( $csrfGuard );
+ * You will need to reconfigure ajax calls accordingly, for example, by copying hidden input value
+ * to header.
+ * If you wish to disable header check, use header option:
+ * $csrfGuard = new \Slim\Middleware\CsrfGuardNeue( array('cookie' => false, 'header' => false) );
+ * In this case only POST value will be checked (for XHR calls too!)
+ *
+ *
+ * See also: https://www.owasp.org/index.php/Session_fixation
+ *
+ * Also do not forget to check and properly set (when needed) response headers related
+ * to Same Origin Policy, like Access-Control-Allow-Origin, Access-Control-Allow-Methods and X-Frame-Options:
+ * https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS
+ * https://developer.mozilla.org/en-US/docs/Web/HTTP/X-Frame-Options
+ *
+ *
+ * @package Slim\Middleware
+ * @author  Stepan Legachev, www.sib.li
+ */
+class CsrfGuardNeue extends \Slim\Middleware
+{
+
+    /**
+     * Form field name.
+     *
+     * @var string
+     */
+    protected $fieldName = 'csrfmiddlewaretoken';
+
+    /**
+     * Cookie name.
+     *
+     * @var string
+     */
+    protected $cookieName = null;
+
+    /**
+     * Header name.
+     * To this header JS should copy cookie value.
+     *
+     * @var string
+     */
+    protected $headerName = null;
+
+    /**
+     * Action to perform on token check failure.
+     *
+     * @var \Closure|callable
+     */
+    public $action = null;
+
+    /**
+     * @var array
+     */
+    protected $settings;
+
+    /**
+     * @var array
+     */
+    public $unsafeMethods = array(
+        \Slim\Http\Request::METHOD_POST,
+        \Slim\Http\Request::METHOD_PUT,
+        \Slim\Http\Request::METHOD_PATCH,
+        \Slim\Http\Request::METHOD_DELETE
+    );
+
+
+    /**
+     *
+     * @param array $settings
+     * @throws \OutOfBoundsException
+     */
+    public function __construct($settings = array())
+    {
+
+        $defaults = array(
+            'field'  => 'csrfmiddlewaretoken',
+            'cookie' => 'XSRF-TOKEN',
+            'header' => 'X-Xsrf-Token',
+            'action' => array($this, 'defaultAction')
+        );
+
+        // Backwards compatibility.
+        if ( is_string($settings) ) {
+            $settings = array('field' => $settings);
+        }
+
+        if ( is_array($settings) ) {
+            $this->settings = array_merge($defaults, $settings);
+        } else {
+            $this->settings = $defaults;
+        }
+
+        $fieldName  = is_string($this->settings['field']) ? trim($this->settings['field']) : false;
+        $cookieName = is_string($this->settings['cookie']) ? trim($this->settings['cookie']) : false;
+        $headerName = is_string($this->settings['header']) ? trim($this->settings['header']) : false;
+
+        if ( empty($fieldName) || preg_match('/[^a-zA-Z0-9\-\_]/', $fieldName) ) {
+            throw new \OutOfBoundsException('Invalid CSRF token field name "' . $fieldName . '"');
+        }
+
+        if ( empty($cookieName) ) {
+            $cookieName = false;
+        } else if ( !is_string($cookieName) || preg_match('/[^a-zA-Z0-9\-\_]/', $cookieName) ) {
+            throw new \OutOfBoundsException('Invalid CSRF token cookie name "' . $cookieName . '"');
+        }
+
+        if ( empty($headerName) ) {
+            $headerName = false;
+        } else if ( !is_string($headerName) || preg_match('/[^a-zA-Z0-9\-\_]/', $headerName) ) {
+            throw new \OutOfBoundsException('Invalid CSRF token header name "' . $headerName . '"');
+        }
+
+        if ( !is_callable($this->settings['action']) ) {
+            $this->action = array($this, 'defaultAction');
+        } else {
+            $this->action = $this->settings['action'];
+            if ( method_exists($this->action, 'bindTo') ) {
+                $this->action = $this->action->bindTo($this, $this);
+            }
+
+        }
+
+        $this->fieldName  = $fieldName;
+        $this->cookieName = $cookieName;
+        $this->headerName = $headerName;
+
+    } // constructor
+
+
+    /**
+     * Call middleware.
+     *
+     * @return void
+     */
+    public function call()
+    {
+
+        // Attach as hook.
+        $this->app->hook('slim.before', array($this, 'check'));
+
+        // Call next middleware.
+        $this->next->call();
+
+    } // call
+
+
+    /**
+     * Default action on token verification fail.
+     *
+     * @param $app \Slim\Slim
+     */
+    protected function defaultAction(\Slim\Slim $app)
+    {
+        if ( $this->isAcceptJSON() || $this->isXHR() ) {
+            $app->contentType("application/json");
+            // Double quoted for JSON-safe response.
+            $app->halt(400, '"Invalid or missing CSRF token"');
+        }
+        $app->halt(400, 'Invalid or missing CSRF token');
+    } // defaultAction
+
+
+    /**
+     * Check CSRF token is valid.
+     * Sets cookie and session variable.
+     *
+     */
+    public function check()
+    {
+
+        // Check sessions are enabled.
+        if (session_id() === '') {
+            throw new \Exception('Sessions are required to use the CSRF Guard middleware.');
+        }
+
+        // @todo Also check referrer and origin
+
+        if ( empty($_SESSION[$this->fieldName]) ) {
+
+            // Slightly modified implementation from https://www.owasp.org/index.php/PHP_CSRF_Guard
+            if ( function_exists("hash_algos") && in_array("sha256", hash_algos()) ) {
+                $token = hash( "sha256", mt_rand() );
+            } else {
+                $token = '';
+                for ($i = 0; $i < 64; ++$i) {
+                    $token .= dechex( mt_rand(0, 15) );
+                }
+            }
+
+            $_SESSION[$this->fieldName] = $token;
+
+        } else {
+            $token = $_SESSION[$this->fieldName];
+        }
+
+
+        // Validate the CSRF token.
+        if ( in_array($this->app->request()->getMethod(), $this->unsafeMethods) ) {
+
+            $userToken = $this->app->request()->post($this->fieldName, false);
+
+            if ( empty($userToken) && $this->headerName !== false ) {
+                $userToken = $this->app->request->headers->get( $this->headerName );
+            }
+
+            if ($token !== $userToken) {
+                call_user_func( $this->action, $this->app );
+            }
+
+        } else {
+            if ($this->cookieName !== false) {
+                // if ( is_null( $app->getCookie($this->cookieName) ) )
+                $this->app->setCookie($this->cookieName, $token, '2 days');
+            }
+        }
+
+        // Assign CSRF token key names and value to view.
+        $this->app->view()->set('csrf_key',   $this->fieldName);
+        $this->app->view()->set('csrf_token', $token);
+
+        if ($this->cookieName !== false) {
+            $this->app->view()->set('csrf_cookie', $this->cookieName);
+        }
+
+        if ( $this->headerName !== false ) {
+            $this->app->view()->set('csrf_header', $this->headerName);
+        }
+
+    } // check
+
+
+    public function isAcceptJSON()
+    {
+        $accept = $this->app->request->headers->get('Accept');
+        return ( stripos($accept, 'application/json') !== false );
+    } // isAcceptJSON
+
+    public function isXHR()
+    {
+        $reqWith = $this->app->request->headers->get('X-Requested-With');
+        return strtolower($reqWith) == strtolower('XMLHttpRequest');
+    } // isXHR
+
+
+} // CsrfGuardNeue class

--- a/src/Slim/Middleware/CsrfGuardNeue/README.md
+++ b/src/Slim/Middleware/CsrfGuardNeue/README.md
@@ -1,0 +1,171 @@
+# Slim Framework CSRF (XSRF) Guard Middleware
+
+Based on [CsrfGuard](https://github.com/codeguy/Slim-Extras/blob/develop/Middleware/CsrfGuard.php) middleware from Slim-Extras.
+
+Provides <a href="https://www.owasp.org/index.php/Cross-Site_Request_Forgery_(CSRF)_Prevention_Cheat_Sheet">CSRF (XSRF) protection</a> for your forms and ajax requests.
+
+Implements cookie set + http header check for ajax requests and CSRF_token (hidden input) for forms.
+
+If your are familiar with Python, this implementation for Slim framework
+is similar to [implementation for Django](https://docs.djangoproject.com/en/dev/ref/contrib/csrf/)
+
+Compatible out of the box with [AngularJS $http provider](https://docs.angularjs.org/api/ng/service/$http#cross-site-request-forgery-xsrf-protection), no additional configuration required.
+
+
+
+## How to Use
+
+Add middleware:
+
+    $app = new \Slim\Slim();
+    $app->add( new \Slim\Middleware\CsrfGuardNeue() );
+
+You can configure hidden input name like this:
+
+    $csrfGuard = new \Slim\Middleware\CsrfGuardNeue('myCustomName');
+    $app->add( $csrfGuard );
+
+Or configure other parameters passing array with key-value options instead of one string argument
+(in this code sample also provided default option values):
+
+    $csrfGuard = new \Slim\Middleware\CsrfGuardNeue( array(
+        'field'  => 'csrfmiddlewaretoken', // Input name
+        'cookie' => 'XSRF-TOKEN',          // Cookie name
+        'header' => 'X-Xsrf-Token',        // Header name
+        // Action on CSRF token validation failure.
+        // Should be callable function. $app will be passed as function parameter.
+        // $this will be changed to CsrfGuardNeue object (PHP 5.4+ only).
+        'action' => function(\Slim\Slim $app) {
+            if ( $this->isAcceptJSON() || $this->isXHR() ) {
+                $app->contentType("application/json");
+                // Double quoted for JSON-safe response.
+                $app->halt(400, '"Invalid or missing CSRF token"');
+            }
+            $app->halt(400, 'Invalid or missing CSRF token');
+        }
+    ) );
+    $app->add( $csrfGuard );
+
+
+In your view template add this hidden input inside every of web forms with action="POST" you have created:
+
+    <input type="hidden" name="<?php echo $csrf_key; ?>" value="<?php echo $csrf_token; ?>" />
+
+Or, if you are using Twig template engine, you can use provided extension.
+
+
+### TwigCsrfHelpers extension usage
+
+1.  Add extension to your stack
+
+        $app->view->parserExtensions = array(
+            new \Slim\Views\TwigExtension(),
+            new \Slim\Middleware\CsrfGuardNeue\TwigCsrfHelpers()
+        );
+
+2.  Insert CSRF token hidden input inside all of your web forms with this simple function:
+
+        <form ...> {{ CSRF() }} ...</form>
+
+    Which will be translated to:
+
+        <form ...> <input type="hidden" name="{{ csrf_key }}" value="{{ csrf_token }}" /> ...</form>
+
+3.  jQuery users needed simple additional configuration. Just add this line before closing `</body>` tag:
+
+        {{ jQcsrf() }}
+
+    or, if you want no `<script></script>` wrapping, just use:
+
+        {{ jQcsrf(false) }}
+
+    This will create required jQuery handler to copy CSRF token value from cookie to request header
+    to be verified by CsrfGuardNeue for every POST, PUT, PATCH and DELETE ajax requests.
+
+
+### jQuery users (when Twig is not used)
+
+If you get data for all of your ajax POST requests from `$("form").serialize()` or `$.serializeArray()` (<http://api.jquery.com/serializeArray/>),
+you need nothing else to configure.
+
+Just make sure you put hidden input in every form (see above).
+
+For any other ajax POST, PUT or DELETE requests you will need some additional setup.
+
+This needed to copy CSRF token value from cookie to request header for every unsafe request
+
+    <script>
+    function getCookie(cname) {
+        var name = cname + '=';
+        var ca = document.cookie.split(';');
+        for (var i = 0; i < ca.length; i++) {
+            var c = $.trim(ca[i]);
+            if (c.indexOf(name) != -1) return c.substring(name.length,c.length);
+        }
+        return null;
+    }
+    $.ajaxSetup({
+        beforeSend: function(xhr, settings) {
+            if (this.crossDomain) return;
+            // These HTTP methods do not require CSRF protection, BUT!
+            // Only if you are not changing any data using these methods in ajax!
+            if ( -1 < (['GET','HEAD','OPTIONS','TRACE']).indexOf(settings.type) ) return;
+            var csrftoken = $.cookie ? $.cookie('XSRF-TOKEN') : getCookie('XSRF-TOKEN');
+            xhr.setRequestHeader("X-XSRF-TOKEN", csrftoken);
+        }
+    });
+    </script>
+
+
+## Limitations
+
+Any sub-domains of your site will be able to get and set cookies (client-side) for the whole domain.
+In this case Cookie+Header protection is useless.
+
+If you have untrusted sub-domains, disable cookie assignment by setting cookie option to false:
+
+    $csrfGuard = new \Slim\Middleware\CsrfGuardNeue( array('cookie' => false) );
+    $app->add( $csrfGuard );
+
+You will need then to reconfigure ajax calls accordingly, for example, by copying hidden input value
+to request header for every ajax request:
+
+    xhr.setRequestHeader("X-XSRF-TOKEN", csrftoken);
+
+If you wish to disable header check, set header option to false:
+
+    $csrfGuard = new \Slim\Middleware\CsrfGuardNeue( array('cookie' => false, 'header' => false) );
+
+In this case token value from POST data will be checked only (yes, for XHR calls too).
+
+
+### Other security tips
+
+Learn about [Session fixation](https://www.owasp.org/index.php/Session_fixation).
+
+Do not forget to check and properly set (when needed) response headers related
+to Same Origin Policy, like `Access-Control-Allow-Origin`, `Access-Control-Allow-Methods` and `X-Frame-Options`:
+
+1. <https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS>
+2. <https://developer.mozilla.org/en-US/docs/Web/HTTP/X-Frame-Options>
+
+
+
+## Author and credits
+
+CsrfGuardNeue provided by [Stepan Legachev](https://www.sib.li).
+
+Thank to [Mikhail Osher](https://github.com/miraage), author of original CsrfGuard middleware,
+and [all of contributors](https://github.com/codeguy/Slim-Extras/commits/develop/Middleware/CsrfGuard.php).
+
+Thanks to [Josh Lockhart](https://github.com/codeguy) for [Slim PHP framework](http://www.slimframework.com/).
+
+Thanks to [Fabien Potencier](https://github.com/fabpot/) for [Twig](http://twig.sensiolabs.org/) templates.
+
+
+
+## License
+
+All code in this repository is released under the MIT public license.
+
+<http://www.slimframework.com/license>

--- a/src/Slim/Middleware/CsrfGuardNeue/TwigCsrfHelpers.php
+++ b/src/Slim/Middleware/CsrfGuardNeue/TwigCsrfHelpers.php
@@ -1,0 +1,132 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: www.sib.li
+ * Date: 17.08.14
+ * Time: 12:48
+ */
+
+namespace Slim\Middleware\CsrfGuardNeue;
+
+/**
+ * Class TwigCsrfHelpers
+ *
+ * Twig helper extension for CsrfGuardNeue middleware.
+ *
+ * Usage:
+ *
+ * 1. Add extension to your stack:
+ * $app->view->parserExtensions = array(
+ *     new \Slim\Views\TwigExtension(),
+ *     new \Slim\Middleware\CsrfGuardNeue\TwigCsrfHelpers()
+ * );
+ *
+ *
+ * 2. Insert inside any form with action="POST":
+ * <form ...> {{ CSRF() }} ...</form>
+ *
+ * Which will be translated to:
+ * <form ...> <input type="hidden" name="{{ csrf_key }}" value="{{ csrf_token }}" /> ...</form>
+ *
+ *
+ * 3. jQuery users need to add this line before closing </body> tag:
+ * {{ jQcsrf() }}
+ *
+ * or, if you want no <script></script> wrapping, just:
+ * {{ jQcsrf(false) }}
+ *
+ * This will create required jQuery handler to copy CSRF token value from cookie to request header
+ * to be verified by CsrfGuardNeue for every POST, PUT, PATCH and DELETE ajax requests.
+ *
+ *
+ * 4. AngularJS $http provider do not require any additional configuration!
+ *
+ *
+ *
+ * @package Slim\Middleware\CsrfGuardNeue
+ * @author  Stepan Legachev, www.sib.li
+ */
+class TwigCsrfHelpers extends \Twig_Extension {
+
+    /**
+     * Returns the name of the extension.
+     *
+     * @return string The extension name
+     */
+    public function getName()
+    {
+        return 'slim-csrf';
+    } // getName
+
+    /**
+     * Returns a list of functions to add to the existing list.
+     *
+     * @return array An array of filters
+     */
+    public function getFunctions()
+    {
+
+        return array(
+            new \Twig_SimpleFunction('CSRF', array($this, 'showInput'), array(
+                'is_safe' => array('html'),
+                'needs_context' => true
+            )),
+
+            new \Twig_SimpleFunction('jQcsrf', array($this, 'jQueryHelper'), array(
+                'is_safe' => array('html', 'js'),
+                'needs_context' => true
+            ))
+        );
+
+    } // getFunctions
+
+    public function showInput($context)
+    {
+        return '<input class="hide" type="hidden" name="'.$context['csrf_key'].'" value="'.$context['csrf_token'].'" />';
+    } //showInput
+
+    public function jQueryHelper($context, $addScriptTag = true)
+    {
+
+        if ( empty($context['csrf_cookie']) ) {
+            return '';
+        }
+        if ( empty($context['csrf_header']) ) {
+            return '';
+        }
+        $cookieName = $context['csrf_cookie'];
+        $headerName = $context['csrf_header'];
+
+        $js = <<<RAWJS
+(function($, undefined) {
+    function getCookie(cname) {
+        var name = cname + '=';
+        var ca = document.cookie.split(';');
+        for (var i = 0; i < ca.length; i++) {
+            var c = $.trim(ca[i]);
+            if ( c.indexOf(name) != -1 ) return c.substring(name.length, c.length);
+        }
+        return null;
+    }
+    $.ajaxSetup({
+        beforeSend: function(xhr, settings) {
+            if (this.crossDomain) return;
+            if ( -1 < (['GET','HEAD','OPTIONS','TRACE']).indexOf(settings.type) ) return;
+            var csrftoken = $.cookie ? $.cookie('{$cookieName}') : getCookie('{$cookieName}');
+            xhr.setRequestHeader('{$headerName}', csrftoken);
+        }
+    });
+} )(jQuery);
+RAWJS;
+
+        if ($addScriptTag) {
+            return "<script>\n{$js}\n</script>";
+        } else {
+            return $js;
+        }
+
+    } // jQueryHelper
+
+
+} // TwigCsrfHelpers class
+


### PR DESCRIPTION
Added CSRF guard with request header check, compatible with AngularJS cookie & header names by default.

Added configuration options including action on token check fail to address issues like this: http://help.slimframework.com/discussions/questions/912-catch-csrf-error

Added helpers for Twig to ease template updates and jQuery configuration
